### PR TITLE
Backward compatibility for chain_code

### DIFF
--- a/src/chain_code/two_party/party1.rs
+++ b/src/chain_code/two_party/party1.rs
@@ -11,12 +11,12 @@
 */
 use curv::cryptographic_primitives::proofs::sigma_dlog::DLogProof;
 use curv::cryptographic_primitives::twoparty::dh_key_exchange_variant_with_pok_comm::*;
-
-use curv::GE;
+use curv::{BigInt, GE};
+use curv::elliptic::curves::traits::ECPoint;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct ChainCode1 {
-    pub chain_code: GE,
+    pub chain_code: BigInt,
 }
 
 impl ChainCode1 {
@@ -34,7 +34,7 @@ impl ChainCode1 {
         party2_first_message_public_share: &GE,
     ) -> ChainCode1 {
         ChainCode1 {
-            chain_code: compute_pubkey(ec_key_pair, party2_first_message_public_share),
+            chain_code: compute_pubkey(ec_key_pair, party2_first_message_public_share).bytes_compressed_to_big_int(),
         }
     }
 }

--- a/src/chain_code/two_party/party1.rs
+++ b/src/chain_code/two_party/party1.rs
@@ -11,8 +11,8 @@
 */
 use curv::cryptographic_primitives::proofs::sigma_dlog::DLogProof;
 use curv::cryptographic_primitives::twoparty::dh_key_exchange_variant_with_pok_comm::*;
-use curv::{BigInt, GE};
 use curv::elliptic::curves::traits::ECPoint;
+use curv::{BigInt, GE};
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct ChainCode1 {
@@ -34,7 +34,8 @@ impl ChainCode1 {
         party2_first_message_public_share: &GE,
     ) -> ChainCode1 {
         ChainCode1 {
-            chain_code: compute_pubkey(ec_key_pair, party2_first_message_public_share).bytes_compressed_to_big_int(),
+            chain_code: compute_pubkey(ec_key_pair, party2_first_message_public_share)
+                .bytes_compressed_to_big_int(),
         }
     }
 }

--- a/src/chain_code/two_party/party2.rs
+++ b/src/chain_code/two_party/party2.rs
@@ -12,8 +12,8 @@
 
 use curv::cryptographic_primitives::proofs::ProofError;
 use curv::cryptographic_primitives::twoparty::dh_key_exchange_variant_with_pok_comm::*;
-use curv::{BigInt, GE};
 use curv::elliptic::curves::traits::ECPoint;
+use curv::{BigInt, GE};
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct ChainCode2 {
@@ -40,7 +40,8 @@ impl ChainCode2 {
         party1_second_message_public_share: &GE,
     ) -> ChainCode2 {
         ChainCode2 {
-            chain_code: compute_pubkey(ec_key_pair, party1_second_message_public_share).bytes_compressed_to_big_int(),
+            chain_code: compute_pubkey(ec_key_pair, party1_second_message_public_share)
+                .bytes_compressed_to_big_int(),
         }
     }
 }

--- a/src/chain_code/two_party/party2.rs
+++ b/src/chain_code/two_party/party2.rs
@@ -12,11 +12,12 @@
 
 use curv::cryptographic_primitives::proofs::ProofError;
 use curv::cryptographic_primitives::twoparty::dh_key_exchange_variant_with_pok_comm::*;
-use curv::GE;
+use curv::{BigInt, GE};
+use curv::elliptic::curves::traits::ECPoint;
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct ChainCode2 {
-    pub chain_code: GE,
+    pub chain_code: BigInt,
 }
 
 impl ChainCode2 {
@@ -39,7 +40,7 @@ impl ChainCode2 {
         party1_second_message_public_share: &GE,
     ) -> ChainCode2 {
         ChainCode2 {
-            chain_code: compute_pubkey(ec_key_pair, party1_second_message_public_share),
+            chain_code: compute_pubkey(ec_key_pair, party1_second_message_public_share).bytes_compressed_to_big_int(),
         }
     }
 }

--- a/src/ecdsa/two_party/mod.rs
+++ b/src/ecdsa/two_party/mod.rs
@@ -10,10 +10,10 @@
     @license GPL-3.0+ <https://github.com/KZen-networks/kms/blob/master/LICENSE>
 */
 
+use curv::arithmetic::traits::Converter;
 use curv::cryptographic_primitives::hashing::hmac_sha512;
 use curv::cryptographic_primitives::hashing::traits::KeyedHash;
 use curv::elliptic::curves::traits::{ECPoint, ECScalar};
-use curv::arithmetic::traits::Converter;
 use curv::{BigInt, FE, GE};
 use multi_party_ecdsa::protocols::two_party_ecdsa::lindell_2017::{party_one, party_two};
 use paillier::*;
@@ -54,7 +54,11 @@ pub mod party1;
 pub mod party2;
 mod test;
 
-pub fn hd_key(mut location_in_hir: Vec<BigInt>, pubkey: &GE, chain_code_bi: &BigInt) -> (GE, FE, GE) {
+pub fn hd_key(
+    mut location_in_hir: Vec<BigInt>,
+    pubkey: &GE,
+    chain_code_bi: &BigInt,
+) -> (GE, FE, GE) {
     let mask = BigInt::from(2).pow(256) - BigInt::one();
     // let public_key = self.public.q.clone();
 
@@ -67,8 +71,8 @@ pub fn hd_key(mut location_in_hir: Vec<BigInt>, pubkey: &GE, chain_code_bi: &Big
     let f_l_fe: FE = ECScalar::from(&f_l);
     let f_r_fe: FE = ECScalar::from(&f_r);
 
-
-    let chain_code = GE::from_bytes(&BigInt::to_vec(chain_code_bi)).unwrap() * &f_r_fe;
+    let bn_to_slice = BigInt::to_vec(chain_code_bi);
+    let chain_code = GE::from_bytes(&bn_to_slice[1..33]).unwrap() * &f_r_fe;
     let pub_key = pubkey * &f_l_fe;
 
     let (public_key_new_child, f_l_new, cc_new) =

--- a/src/ecdsa/two_party/mod.rs
+++ b/src/ecdsa/two_party/mod.rs
@@ -10,11 +10,10 @@
     @license GPL-3.0+ <https://github.com/KZen-networks/kms/blob/master/LICENSE>
 */
 
-use chain_code::two_party::party1::ChainCode1;
-use chain_code::two_party::party2::ChainCode2;
 use curv::cryptographic_primitives::hashing::hmac_sha512;
 use curv::cryptographic_primitives::hashing::traits::KeyedHash;
 use curv::elliptic::curves::traits::{ECPoint, ECScalar};
+use curv::arithmetic::traits::Converter;
 use curv::{BigInt, FE, GE};
 use multi_party_ecdsa::protocols::two_party_ecdsa::lindell_2017::{party_one, party_two};
 use paillier::*;
@@ -32,7 +31,7 @@ pub struct Party1Public {
 pub struct MasterKey1 {
     pub public: Party1Public,
     private: party_one::Party1Private,
-    chain_code: ChainCode1,
+    chain_code: BigInt,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
@@ -48,17 +47,16 @@ pub struct Party2Public {
 pub struct MasterKey2 {
     pub public: Party2Public,
     pub private: party_two::Party2Private,
-    pub chain_code: ChainCode2,
+    pub chain_code: BigInt,
 }
 
 pub mod party1;
 pub mod party2;
 mod test;
 
-pub fn hd_key(mut location_in_hir: Vec<BigInt>, pubkey: &GE, chain_code: &GE) -> (GE, FE, GE) {
+pub fn hd_key(mut location_in_hir: Vec<BigInt>, pubkey: &GE, chain_code_bi: &BigInt) -> (GE, FE, GE) {
     let mask = BigInt::from(2).pow(256) - BigInt::one();
     // let public_key = self.public.q.clone();
-    let chain_code_bi = chain_code.bytes_compressed_to_big_int();
 
     // calc first element:
     let first = location_in_hir.remove(0);
@@ -68,7 +66,9 @@ pub fn hd_key(mut location_in_hir: Vec<BigInt>, pubkey: &GE, chain_code: &GE) ->
     let f_r = &f & &mask;
     let f_l_fe: FE = ECScalar::from(&f_l);
     let f_r_fe: FE = ECScalar::from(&f_r);
-    let chain_code = chain_code * &f_r_fe;
+
+
+    let chain_code = GE::from_bytes(&BigInt::to_vec(chain_code_bi)).unwrap() * &f_r_fe;
     let pub_key = pubkey * &f_l_fe;
 
     let (public_key_new_child, f_l_new, cc_new) =

--- a/src/ecdsa/two_party/party1.rs
+++ b/src/ecdsa/two_party/party1.rs
@@ -12,10 +12,10 @@
 use curv::cryptographic_primitives::proofs::sigma_dlog::DLogProof;
 use curv::elliptic::curves::traits::ECScalar;
 use curv::{BigInt, FE, GE};
+use curv::elliptic::curves::traits::ECPoint;
 
 use super::hd_key;
 use super::{MasterKey1, MasterKey2, Party1Public};
-use curv::elliptic::curves::traits::ECPoint;
 use ecdsa::two_party::party2::SignMessage;
 use multi_party_ecdsa::protocols::two_party_ecdsa::lindell_2017::party_two::EphKeyGenFirstMsg;
 use multi_party_ecdsa::protocols::two_party_ecdsa::lindell_2017::party_two::PDLFirstMessage as Party2PDLFirstMsg;

--- a/src/ecdsa/two_party/party1.rs
+++ b/src/ecdsa/two_party/party1.rs
@@ -15,12 +15,12 @@ use curv::{BigInt, FE, GE};
 
 use super::hd_key;
 use super::{MasterKey1, MasterKey2, Party1Public};
-use chain_code::two_party::party1::ChainCode1;
 use ecdsa::two_party::party2::SignMessage;
 use multi_party_ecdsa::protocols::two_party_ecdsa::lindell_2017::party_two::EphKeyGenFirstMsg;
 use multi_party_ecdsa::protocols::two_party_ecdsa::lindell_2017::party_two::PDLFirstMessage as Party2PDLFirstMsg;
 use multi_party_ecdsa::protocols::two_party_ecdsa::lindell_2017::party_two::PDLSecondMessage as Party2PDLSecondMsg;
 use multi_party_ecdsa::protocols::two_party_ecdsa::lindell_2017::{party_one, party_two};
+use curv::elliptic::curves::traits::ECPoint;
 
 use paillier::EncryptionKey;
 use rotation::two_party::Rotation;
@@ -69,7 +69,7 @@ impl MasterKey1 {
 
     pub fn get_child(&self, location_in_hir: Vec<BigInt>) -> MasterKey1 {
         let (public_key_new_child, f_l_new, cc_new) =
-            hd_key(location_in_hir, &self.public.q, &self.chain_code.chain_code);
+            hd_key(location_in_hir, &self.public.q, &self.chain_code);
 
         let public = Party1Public {
             q: public_key_new_child,
@@ -81,12 +81,12 @@ impl MasterKey1 {
         MasterKey1 {
             public,
             private: self.private.clone(),
-            chain_code: ChainCode1 { chain_code: cc_new },
+            chain_code: cc_new.bytes_compressed_to_big_int()
         }
     }
 
     pub fn set_master_key(
-        chain_code: &GE,
+        chain_code: &BigInt,
         party_one_private: party_one::Party1Private,
         party_one_public_ec_key: &GE,
         party2_first_message_public_share: &GE,
@@ -103,9 +103,7 @@ impl MasterKey1 {
         MasterKey1 {
             public: party1_public,
             private: party_one_private,
-            chain_code: ChainCode1 {
-                chain_code: chain_code.clone(),
-            },
+            chain_code: chain_code.clone(),
         }
     }
 
@@ -119,7 +117,7 @@ impl MasterKey1 {
         };
         // set master keys:
         MasterKey2::set_master_key(
-            &self.chain_code.chain_code,
+            &self.chain_code,
             &ec_key_pair_party2,
             &ec_key_pair_party2.public_share,
             &party_two_paillier,
@@ -129,7 +127,7 @@ impl MasterKey1 {
     pub fn recover_master_key(
         recovered_secret: FE,
         party_one_public: Party1Public,
-        chain_code: ChainCode1,
+        chain_code: BigInt,
     ) -> MasterKey1 {
         //  master key of party one from party one secret recovery:
         // q2 (public key of party two), chain code, and paillier data are needed for

--- a/src/ecdsa/two_party/party1.rs
+++ b/src/ecdsa/two_party/party1.rs
@@ -15,12 +15,12 @@ use curv::{BigInt, FE, GE};
 
 use super::hd_key;
 use super::{MasterKey1, MasterKey2, Party1Public};
+use curv::elliptic::curves::traits::ECPoint;
 use ecdsa::two_party::party2::SignMessage;
 use multi_party_ecdsa::protocols::two_party_ecdsa::lindell_2017::party_two::EphKeyGenFirstMsg;
 use multi_party_ecdsa::protocols::two_party_ecdsa::lindell_2017::party_two::PDLFirstMessage as Party2PDLFirstMsg;
 use multi_party_ecdsa::protocols::two_party_ecdsa::lindell_2017::party_two::PDLSecondMessage as Party2PDLSecondMsg;
 use multi_party_ecdsa::protocols::two_party_ecdsa::lindell_2017::{party_one, party_two};
-use curv::elliptic::curves::traits::ECPoint;
 
 use paillier::EncryptionKey;
 use rotation::two_party::Rotation;
@@ -81,7 +81,7 @@ impl MasterKey1 {
         MasterKey1 {
             public,
             private: self.private.clone(),
-            chain_code: cc_new.bytes_compressed_to_big_int()
+            chain_code: cc_new.bytes_compressed_to_big_int(),
         }
     }
 

--- a/src/ecdsa/two_party/party1.rs
+++ b/src/ecdsa/two_party/party1.rs
@@ -10,9 +10,9 @@
     @license GPL-3.0+ <https://github.com/KZen-networks/kms/blob/master/LICENSE>
 */
 use curv::cryptographic_primitives::proofs::sigma_dlog::DLogProof;
+use curv::elliptic::curves::traits::ECPoint;
 use curv::elliptic::curves::traits::ECScalar;
 use curv::{BigInt, FE, GE};
-use curv::elliptic::curves::traits::ECPoint;
 
 use super::hd_key;
 use super::{MasterKey1, MasterKey2, Party1Public};

--- a/src/ecdsa/two_party/party2.rs
+++ b/src/ecdsa/two_party/party2.rs
@@ -21,7 +21,7 @@ use multi_party_ecdsa::protocols::two_party_ecdsa::lindell_2017::{party_one, par
 
 use super::hd_key;
 use super::{MasterKey1, MasterKey2, Party2Public};
-use chain_code::two_party::party2::ChainCode2;
+use curv::elliptic::curves::traits::ECPoint;
 use curv::elliptic::curves::traits::ECScalar;
 use rotation::two_party::Rotation;
 
@@ -62,7 +62,7 @@ impl MasterKey2 {
 
     pub fn get_child(&self, location_in_hir: Vec<BigInt>) -> MasterKey2 {
         let (public_key_new_child, f_l_new, cc_new) =
-            hd_key(location_in_hir, &self.public.q, &self.chain_code.chain_code);
+            hd_key(location_in_hir, &self.public.q, &self.chain_code);
 
         let public = Party2Public {
             q: public_key_new_child,
@@ -77,12 +77,12 @@ impl MasterKey2 {
                 &self.private,
                 &f_l_new.to_big_int(),
             ),
-            chain_code: ChainCode2 { chain_code: cc_new },
+            chain_code: cc_new.bytes_compressed_to_big_int()
         }
     }
 
     pub fn set_master_key(
-        chain_code: &GE,
+        chain_code: &BigInt,
         ec_key_pair_party2: &party_two::EcKeyPair,
         party1_second_message_public_share: &GE,
         paillier_public: &party_two::PaillierPublic,
@@ -98,9 +98,7 @@ impl MasterKey2 {
         MasterKey2 {
             public: party2_public,
             private: party2_private,
-            chain_code: ChainCode2 {
-                chain_code: chain_code.clone(),
-            },
+            chain_code: chain_code.clone(),
         }
     }
 
@@ -116,7 +114,7 @@ impl MasterKey2 {
 
         // set master keys:
         MasterKey1::set_master_key(
-            &self.chain_code.chain_code,
+            &self.chain_code,
             party_one_private,
             &ec_key_pair_party1.public_share,
             &self.public.p2,
@@ -127,7 +125,7 @@ impl MasterKey2 {
     pub fn recover_master_key(
         recovered_secret: FE,
         party_two_public: Party2Public,
-        chain_code: ChainCode2,
+        chain_code: BigInt,
     ) -> MasterKey2 {
         //  master key of party two from party two secret recovery:
         // q1 (public key of party one), chain code, and public paillier data (c_key, ek) are needed for

--- a/src/ecdsa/two_party/party2.rs
+++ b/src/ecdsa/two_party/party2.rs
@@ -77,7 +77,7 @@ impl MasterKey2 {
                 &self.private,
                 &f_l_new.to_big_int(),
             ),
-            chain_code: cc_new.bytes_compressed_to_big_int()
+            chain_code: cc_new.bytes_compressed_to_big_int(),
         }
     }
 

--- a/src/ecdsa/two_party/test.rs
+++ b/src/ecdsa/two_party/test.rs
@@ -430,7 +430,7 @@ mod tests {
         );
         // set master keys:
         let party_one_master_key = MasterKey1::set_master_key(
-            &party1_cc.chain_code.bytes_compressed_to_big_int(),
+            &party1_cc.chain_code,
             party_one_private,
             &kg_comm_witness.public_share,
             &kg_party_two_first_message.public_share,
@@ -438,7 +438,7 @@ mod tests {
         );
 
         let party_two_master_key = MasterKey2::set_master_key(
-            &party2_cc.chain_code.bytes_compressed_to_big_int(),
+            &party2_cc.chain_code,
             &kg_ec_key_pair_party2,
             &kg_party_one_second_message
                 .ecdh_second_message

--- a/src/ecdsa/two_party/test.rs
+++ b/src/ecdsa/two_party/test.rs
@@ -430,7 +430,7 @@ mod tests {
         );
         // set master keys:
         let party_one_master_key = MasterKey1::set_master_key(
-            &party1_cc.chain_code,
+            &party1_cc.chain_code.bytes_compressed_to_big_int(),
             party_one_private,
             &kg_comm_witness.public_share,
             &kg_party_two_first_message.public_share,
@@ -438,7 +438,7 @@ mod tests {
         );
 
         let party_two_master_key = MasterKey2::set_master_key(
-            &party2_cc.chain_code,
+            &party2_cc.chain_code.bytes_compressed_to_big_int(),
             &kg_ec_key_pair_party2,
             &kg_party_one_second_message
                 .ecdh_second_message

--- a/src/schnorr/two_party/mod.rs
+++ b/src/schnorr/two_party/mod.rs
@@ -16,10 +16,10 @@
 
 use chain_code::two_party::party1::ChainCode1;
 use chain_code::two_party::party2::ChainCode2;
+use curv::arithmetic::traits::Converter;
 use curv::cryptographic_primitives::hashing::hmac_sha512;
 use curv::cryptographic_primitives::hashing::traits::KeyedHash;
 use curv::elliptic::curves::traits::{ECPoint, ECScalar};
-use curv::arithmetic::traits::Converter;
 use curv::{BigInt, FE, GE};
 use multi_party_schnorr::protocols::multisig::KeyPair;
 // since this special case requires two out of two signers we ignore the "accountable" property
@@ -40,7 +40,11 @@ pub mod party1;
 pub mod party2;
 mod test;
 
-pub fn hd_key(mut location_in_hir: Vec<BigInt>, pubkey: &GE, chain_code_bi: &BigInt) -> (GE, FE, GE) {
+pub fn hd_key(
+    mut location_in_hir: Vec<BigInt>,
+    pubkey: &GE,
+    chain_code_bi: &BigInt,
+) -> (GE, FE, GE) {
     let mask = BigInt::from(2).pow(256) - BigInt::one();
 
     // calc first element:

--- a/src/schnorr/two_party/party1.rs
+++ b/src/schnorr/two_party/party1.rs
@@ -19,10 +19,10 @@ use super::{MasterKey1, MasterKey2};
 use chain_code::two_party::party1::ChainCode1;
 use chain_code::two_party::party2::ChainCode2;
 use curv::arithmetic::traits::Converter;
+use curv::elliptic::curves::traits::ECPoint;
 use curv::elliptic::curves::traits::ECScalar;
 use curv::{BigInt, FE, GE};
 use multi_party_schnorr::protocols::multisig::*;
-use curv::elliptic::curves::traits::ECPoint;
 use rotation::two_party::Rotation;
 use schnorr::two_party::party2::{
     KeyGenParty2Message1, KeyGenParty2Message2, SignParty2Message1, SignParty2Message2,
@@ -187,7 +187,9 @@ impl ManagementSystem2PSchnorr for MasterKey1 {
         local_key_pair_updated.update_key_pair(f_l_new);
         MasterKey1 {
             local_key_pair: local_key_pair_updated,
-            chain_code: ChainCode1 { chain_code: cc_new.bytes_compressed_to_big_int() },
+            chain_code: ChainCode1 {
+                chain_code: cc_new.bytes_compressed_to_big_int(),
+            },
             pubkey: public_key_new_child,
         }
     }

--- a/src/schnorr/two_party/party1.rs
+++ b/src/schnorr/two_party/party1.rs
@@ -22,6 +22,7 @@ use curv::arithmetic::traits::Converter;
 use curv::elliptic::curves::traits::ECScalar;
 use curv::{BigInt, FE, GE};
 use multi_party_schnorr::protocols::multisig::*;
+use curv::elliptic::curves::traits::ECPoint;
 use rotation::two_party::Rotation;
 use schnorr::two_party::party2::{
     KeyGenParty2Message1, KeyGenParty2Message2, SignParty2Message1, SignParty2Message2,
@@ -186,7 +187,7 @@ impl ManagementSystem2PSchnorr for MasterKey1 {
         local_key_pair_updated.update_key_pair(f_l_new);
         MasterKey1 {
             local_key_pair: local_key_pair_updated,
-            chain_code: ChainCode1 { chain_code: cc_new },
+            chain_code: ChainCode1 { chain_code: cc_new.bytes_compressed_to_big_int() },
             pubkey: public_key_new_child,
         }
     }

--- a/src/schnorr/two_party/party2.rs
+++ b/src/schnorr/two_party/party2.rs
@@ -20,6 +20,7 @@ use chain_code::two_party::party1::ChainCode1;
 use chain_code::two_party::party2::ChainCode2;
 use curv::arithmetic::traits::Converter;
 use curv::elliptic::curves::traits::ECScalar;
+use curv::elliptic::curves::traits::ECPoint;
 use curv::{BigInt, FE, GE};
 use multi_party_schnorr::protocols::multisig::*;
 use rotation::two_party::Rotation;
@@ -183,7 +184,7 @@ impl ManagementSystem2PSchnorr for MasterKey2 {
 
         MasterKey2 {
             local_key_pair: local_key_pair_updated,
-            chain_code: ChainCode2 { chain_code: cc_new },
+            chain_code: ChainCode2 { chain_code: cc_new.bytes_compressed_to_big_int() },
             pubkey: public_key_new_child,
         }
     }

--- a/src/schnorr/two_party/party2.rs
+++ b/src/schnorr/two_party/party2.rs
@@ -19,8 +19,8 @@ use super::{MasterKey1, MasterKey2};
 use chain_code::two_party::party1::ChainCode1;
 use chain_code::two_party::party2::ChainCode2;
 use curv::arithmetic::traits::Converter;
-use curv::elliptic::curves::traits::ECScalar;
 use curv::elliptic::curves::traits::ECPoint;
+use curv::elliptic::curves::traits::ECScalar;
 use curv::{BigInt, FE, GE};
 use multi_party_schnorr::protocols::multisig::*;
 use rotation::two_party::Rotation;
@@ -184,7 +184,9 @@ impl ManagementSystem2PSchnorr for MasterKey2 {
 
         MasterKey2 {
             local_key_pair: local_key_pair_updated,
-            chain_code: ChainCode2 { chain_code: cc_new.bytes_compressed_to_big_int() },
+            chain_code: ChainCode2 {
+                chain_code: cc_new.bytes_compressed_to_big_int(),
+            },
             pubkey: public_key_new_child,
         }
     }


### PR DESCRIPTION
Revert field chain_code to BigInt instead of Point (GE) for backward compatibility support.

```
test chain_code::two_party::test::tests::test_chain_code ... ok
test rotation::two_party::test::tests::test_coin_flip ... ok
test schnorr::two_party::test::tests::test_get_child ... ok
test schnorr::two_party::test::tests::test_flip_masters ... ok
test schnorr::two_party::test::tests::test_key_gen ... ok
test schnorr::two_party::test::tests::test_commutativity_rotate_get_child ... ok
test ecdsa::two_party::test::tests::test_get_child ... ok
test ecdsa::two_party::test::tests::test_flip_masters ... ok
test schnorr::two_party::test::tests::test_recovery_scenarios ... ok
test ecdsa::two_party::test::tests::test_recovery_scenarios ... ok
test ecdsa::two_party::test::tests::test_commutativity_rotate_get_child ... ok
```